### PR TITLE
subvolume: fix compile error on ARM by casting statfs.Type to uint32

### DIFF
--- a/pkg/btrfs/subvolume.go
+++ b/pkg/btrfs/subvolume.go
@@ -35,7 +35,8 @@ func IsSubvolume(path string) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	return statfs.Type == BTRFS_SUPER_MAGIC, nil
+	// Cast to uint32 avoids compile error on arm: "constant 2435016766 overflows int32"
+	return uint32(statfs.Type) == BTRFS_SUPER_MAGIC, nil
 }
 
 // CreateSubvolume creates a subvolume at the given path.


### PR DESCRIPTION
On ARM, `statfs.Type` may be interpreted as int32, causing a "constant 2435016766 overflows int32" compile error. Fix this by explicitly casting `statfs.Type` to uint32.